### PR TITLE
Fix proposal for JENKINS-18345

### DIFF
--- a/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
+++ b/src/main/java/hudson/plugins/ws_cleanup/WsCleanup.java
@@ -176,7 +176,7 @@ public class WsCleanup extends Notifier implements MatrixAggregatable {
 	}
 	
     public BuildStepMonitor getRequiredMonitorService(){
-    	return BuildStepMonitor.STEP;
+    	return BuildStepMonitor.NONE;
     }
     
     @Override


### PR DESCRIPTION
Change the returned value from getRequiredMonitorService method to BuildStepMonitor.NONE.
